### PR TITLE
feat: add holidays option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ dayjs('2020-12-25').businessWeeksInMonth();
 // ]
 ```
 
+### isHoliday() => Boolean
+
+Check if the date is a holiday. Returns **true** or **false**
+
+```javascript
+// Add holidays to plugin options
+const options = {
+  holidays: ['2020-12-25'],
+  holidayFormat: 'YYYY-MM-DD',
+};
+dayjs.extend(businessDays, options);
+
+// Christmas day is a Friday
+dayjs('2020-12-25').isHoliday(); // returns true
+```
+
 ## Local Development and Contributing
 
 We are more than happy to accept PRs for bugs, improvements or new features.

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,15 @@
-export default (option, dayjsClass) => {
+export default (option = {}, dayjsClass) => {
+  dayjsClass.prototype.isHoliday = function () {
+    if (!option.holidays) return false;
+    if (option.holidays.includes(this.format(option.holidayFormat))) return true;
+
+    return false;
+  };
+
   dayjsClass.prototype.isBusinessDay = function () {
     const workingWeekdays = [1, 2, 3, 4, 5];
 
+    if (this.isHoliday()) return false;
     if (workingWeekdays.includes(this.day())) return true;
 
     return false;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,3 +70,19 @@ it('Should return a two dimensional array of businessWeeks in a given month', ()
   expect(dayjs('2019-12-15').businessWeeksInMonth()[4].length).toBe(2);
   expect(dayjs('2019-12-15').businessWeeksInMonth()[1][4].valueOf()).toBe(dayjs('2019-12-13').valueOf());
 });
+
+it('Should not be a business day on holidays', () => {
+  const july4th = '2020-07-04';
+  const laborDay = '2020-09-07';
+
+  const options = {
+    holidays: [july4th, laborDay],
+    holidayFormat: 'YYYY-MM-DD',
+  };
+
+  dayjs.extend(businessDays, options);
+  expect(dayjs('2020-07-04T00:00:00.000').isBusinessDay()).toBe(false);
+  expect(dayjs('2020-09-07T00:00:00.000').isBusinessDay()).toBe(false);
+  expect(dayjs('2020-07-04T00:00:00.000').isHoliday()).toBe(true);
+  expect(dayjs('2020-09-07T00:00:00.000').isHoliday()).toBe(true);
+});


### PR DESCRIPTION
Adds an option to pass an array with holidays and a date format. 

I tried to do something like the [moment-business-days](https://github.com/kalmecak/moment-business-days) but I couldn't find a way to work with the [UpdateLocale](https://day.js.org/docs/en/plugin/update-locale) and [LocaleData](https://day.js.org/docs/en/plugin/locale-data) to add the holidays and access them by Day.js class.

My solution was to use the options parameter, which does the job as well but not as elegant. 

Waiting for some feedback!