### PR TITLE
"workingWeekdays" is now configurable in the `options` parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "jest --coverage",
     "build": "babel src -d build",
     "minify": "terser build/index.js --compress --mangle --output index.min.js",
-    "build:minify": "yarn build && yarn minify && rm -rf build"
+    "build:minify": "yarn build && yarn minify && rm -rf build",
+    "prepare": "npm run build:minify"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export default (option = {}, dayjsClass) => {
   };
 
   dayjsClass.prototype.isBusinessDay = function () {
-    const workingWeekdays = [1, 2, 3, 4, 5];
+    const workingWeekdays = option.workingWeekdays ? option.workingWeekdays : [1, 2, 3, 4, 5];
 
     if (this.isHoliday()) return false;
     if (workingWeekdays.includes(this.day())) return true;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,15 @@
 import dayjs from 'dayjs';
 import businessDays from '../src';
 
-dayjs.extend(businessDays);
+const july4th = '2020-07-04';
+const laborDay = '2020-09-07';
+
+const options = {
+  holidays: [july4th, laborDay],
+  holidayFormat: 'YYYY-MM-DD',
+};
+
+dayjs.extend(businessDays, options);
 
 it('Should only be a business day Monday to Friday', () => {
   expect(dayjs().startOf('week').isBusinessDay()).toBe(false);
@@ -72,15 +80,6 @@ it('Should return a two dimensional array of businessWeeks in a given month', ()
 });
 
 it('Should not be a business day on holidays', () => {
-  const july4th = '2020-07-04';
-  const laborDay = '2020-09-07';
-
-  const options = {
-    holidays: [july4th, laborDay],
-    holidayFormat: 'YYYY-MM-DD',
-  };
-
-  dayjs.extend(businessDays, options);
   expect(dayjs('2020-07-04T00:00:00.000').isBusinessDay()).toBe(false);
   expect(dayjs('2020-09-07T00:00:00.000').isBusinessDay()).toBe(false);
   expect(dayjs('2020-07-04T00:00:00.000').isHoliday()).toBe(true);


### PR DESCRIPTION
- `workingWeekdays` is now configurable in the `options` parameter
- Fixed unit tests error
- Added `prepare` NPM script to automatically build when run `npm install`